### PR TITLE
Conditionalize Ubuntu Camera Headers

### DIFF
--- a/compat/media/camera_service.cpp
+++ b/compat/media/camera_service.cpp
@@ -23,7 +23,10 @@
 #include "media_recorder_factory.h"
 #include "media_recorder.h"
 
-//#include <media/camera_record_service.h>
+#if ANDROID_VERSION_MAJOR==5 && WANT_UBUNTU_CAMERA_HEADERS
+#include <media/camera_record_service.h>
+#endif
+
 #include <CameraService.h>
 
 #include <signal.h>
@@ -45,7 +48,9 @@ int main(int argc, char** argv)
     // for creating a new IMediaRecorder (MediaRecorder) instance over Binder
     MediaRecorderFactory::instantiate();
     // Enable audio recording for camera recording
-    // CameraRecordService::instantiate();
+#if ANDROID_VERSION_MAJOR==5 && WANT_UBUNTU_CAMERA_HEADERS
+    CameraRecordService::instantiate();
+#endif
     CameraService::instantiate();
     ProcessState::self()->startThreadPool();
     IPCThreadState::self()->joinThreadPool();

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -72,6 +72,12 @@ AC_ARG_ENABLE(mesa,
   [mesa="no"])
 AM_CONDITIONAL( [WANT_MESA], [test x"$mesa" = x"yes"])
 
+AC_ARG_ENABLE(ubuntu-camera-headers,
+  [  --enable-ubuntu-camera-headers            Enable Ubuntu camera headers (default=disabled)],
+  [ubuntu-camera-headers=$enableval],
+  [ubuntu-camera-headers="no"])
+AM_CONDITIONAL( [WANT_UBUNTU_CAMERA_HEADERS], [test x"$ubuntu-camera-headers" = x"yes"])
+
 AC_ARG_ENABLE(wayland,
   [  --enable-wayland            Enable wayland support (default=disabled)],
   [wayland=$enableval


### PR DESCRIPTION
When using libcompat with Android 5 based targets, you need camera_record_service.h which is only available in a custom android_frameworks_av provided by UBPort as per https://github.com/Halium/android_frameworks_av/commit/8c7eb3192f9db154a7a30d51e1b7d71fbb593593#diff-acd02045aea005cfc1fba66138b25595

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>