### PR TITLE
Halium 7.1 Camfixes

### DIFF
--- a/compat/camera/camera_compatibility_layer.cpp
+++ b/compat/camera/camera_compatibility_layer.cpp
@@ -325,10 +325,13 @@ void android_camera_enumerate_supported_flash_modes(CameraControl* control, flas
 	assert(control);
 
 	android::Mutex::Autolock al(control->guard);
-	android::String8 raw_modes;
-	raw_modes = android::String8(
+	const char* raw_modes_cstr =
 			control->camera_parameters.get(
-				android::CameraParameters::KEY_SUPPORTED_FLASH_MODES));
+				android::CameraParameters::KEY_SUPPORTED_FLASH_MODES);
+	if (!raw_modes_cstr)
+		return;
+
+	android::String8 raw_modes = android::String8(raw_modes_cstr);
 
 	const char delimiter[2] = ",";
 	char *token;

--- a/compat/media/Android.mk
+++ b/compat/media/Android.mk
@@ -9,6 +9,10 @@ endif
 include $(CLEAR_VARS)
 include $(LOCAL_PATH)/../Android.common.mk
 
+ifeq ($(CAMERA_SERVICE_WANT_UBUNTU_HEADERS),1)
+    LOCAL_CPPFLAGS += -DWANT_UBUNTU_CAMERA_HEADERS
+endif
+
 LOCAL_SRC_FILES := \
 	camera_service.cpp
 


### PR DESCRIPTION
This PR provides:
- Conditional enablement of the WANT_UBUNTU_CAMERA_HEADERS from Android-side device makefiles
- A fix for segfaulting while switching to a camera without flash light