### PR TITLE
allow default HYBRIS_MEDIA_32_BIT_ONLY override

### DIFF
--- a/compat/camera/Android.mk
+++ b/compat/camera/Android.mk
@@ -1,6 +1,8 @@
 LOCAL_PATH:= $(call my-dir)
 
+ifeq ($(HYBRIS_MEDIA_32_BIT_ONLY),)
 HYBRIS_MEDIA_32_BIT_ONLY := $(shell cat frameworks/av/media/libmediaplayerservice/Android.mk |grep LOCAL_32_BIT_ONLY |grep -o "true\|false")
+endif
 
 ifeq ($(HYBRIS_MEDIA_32_BIT_ONLY),true)
 HYBRIS_MEDIA_MULTILIB := 32

--- a/compat/media/Android.mk
+++ b/compat/media/Android.mk
@@ -1,6 +1,8 @@
 LOCAL_PATH:= $(call my-dir)
 
+ifeq ($(HYBRIS_MEDIA_32_BIT_ONLY),)
 HYBRIS_MEDIA_32_BIT_ONLY := $(shell cat frameworks/av/media/libmediaplayerservice/Android.mk |grep LOCAL_32_BIT_ONLY |grep -o "true\|false")
+endif
 
 ifeq ($(HYBRIS_MEDIA_32_BIT_ONLY),true)
 HYBRIS_MEDIA_MULTILIB := 32


### PR DESCRIPTION
allow 64bit by adding HYBRIS_MEDIA_32_BIT_ONLY := false to device.mk
(needed for ubports arm64 rootfs)