### PR TITLE
compat: fix camera preview failure when changing viewfinder resolution

### DIFF
--- a/compat/camera/camera_compatibility_layer.cpp
+++ b/compat/camera/camera_compatibility_layer.cpp
@@ -695,10 +695,19 @@ void android_camera_set_preview_texture(CameraControl* control, int texture_id)
 	REPORT_FUNCTION();
 	assert(control);
 
+	if (texture_id == 0) {
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
+		control->camera->setPreviewTexture(NULL);
+#else
+		control->camera->setPreviewTarget(NULL);
+#endif
+		return;
+	}
+
 	static const bool allow_synchronous_mode = false;
 	static const bool is_controlled_by_app = true;
 
-	if (control->preview_texture == NULL) {
+	if (control->preview_texture == NULL || control->preview_texture_id != texture_id) {
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 		android::sp<android::NativeBufferAlloc> native_alloc(
 			new android::NativeBufferAlloc()
@@ -747,6 +756,8 @@ void android_camera_set_preview_texture(CameraControl* control, int texture_id)
 					true,
 					is_controlled_by_app));
 #endif
+
+		control->preview_texture_id = texture_id;
 	}
 
 	control->preview_texture->setFrameAvailableListener(

--- a/compat/camera/camera_compatibility_layer.cpp
+++ b/compat/camera/camera_compatibility_layer.cpp
@@ -698,27 +698,29 @@ void android_camera_set_preview_texture(CameraControl* control, int texture_id)
 	static const bool allow_synchronous_mode = false;
 	static const bool is_controlled_by_app = true;
 
+	if (control->preview_texture == NULL) {
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
-	android::sp<android::NativeBufferAlloc> native_alloc(
+		android::sp<android::NativeBufferAlloc> native_alloc(
 			new android::NativeBufferAlloc()
 			);
 #endif
 
 #if ANDROID_VERSION_MAJOR>=5
-	android::sp<android::IGraphicBufferProducer> producer;
-	android::sp<android::IGraphicBufferConsumer> consumer;
-	android::BufferQueue::createBufferQueue(&producer, &consumer);
+		android::sp<android::IGraphicBufferProducer> producer;
+		android::sp<android::IGraphicBufferConsumer> consumer;
+		android::BufferQueue::createBufferQueue(&producer, &consumer);
+		control->preview_bq = producer;
 #else
-	android::sp<android::BufferQueue> buffer_queue(
+		android::sp<android::BufferQueue> buffer_queue(
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 			new android::BufferQueue(false, NULL, native_alloc)
 #else
 			new android::BufferQueue(NULL)
 #endif
 			);
+		control->preview_bq = buffer_queue;
 #endif
 
-	if (control->preview_texture == NULL) {
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=2
 		control->preview_texture = android::sp<android::SurfaceTexture>(
 				new android::SurfaceTexture(
@@ -755,11 +757,11 @@ void android_camera_set_preview_texture(CameraControl* control, int texture_id)
 #endif
 
 #if ANDROID_VERSION_MAJOR>=5
-	control->camera->setPreviewTarget(producer);
+	control->camera->setPreviewTarget(control->preview_bq);
 #elif ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 	control->camera->setPreviewTexture(control->preview_texture->getBufferQueue());
 #else
-	control->camera->setPreviewTarget(buffer_queue);
+	control->camera->setPreviewTarget(control->preview_bq);
 #endif
 }
 

--- a/hybris/include/hybris/internal/camera_control.h
+++ b/hybris/include/hybris/internal/camera_control.h
@@ -48,6 +48,7 @@ struct CameraControl : public android::CameraListener,
     CameraControlListener* listener;
     android::sp<android::Camera> camera;
     android::CameraParameters camera_parameters;
+    int preview_texture_id = 0;
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=2
     android::sp<android::SurfaceTexture> preview_texture;
 #else

--- a/hybris/include/hybris/internal/camera_control.h
+++ b/hybris/include/hybris/internal/camera_control.h
@@ -53,6 +53,11 @@ struct CameraControl : public android::CameraListener,
 #else
     android::sp<android::GLConsumer> preview_texture;
 #endif
+#if ANDROID_VERSION_MAJOR >= 5
+    android::sp<android::IGraphicBufferProducer> preview_bq;
+#else
+    android::sp<android::BufferQueue> preview_bq;
+#endif
     // From android::SurfaceTexture/GLConsumer::FrameAvailableListener
 #if ANDROID_VERSION_MAJOR==5 && ANDROID_VERSION_MINOR>=1 || ANDROID_VERSION_MAJOR>=6
     void onFrameAvailable(const android::BufferItem& item);


### PR DESCRIPTION
As part of qtubuntu-camera's viewfinder resolution change, it has to stop & re-start the camera preview. And as part of the preview starting code, it re-set the preview texture. A logic bug causes it to pass an uninitialized BufferQueue{,Producer}, causing the preview to fail. This PR fixes that, along with a bit more logic to handle texture change correctly.

This PR uses a custom merge-base to facilitate merging to multiple branches. See https://devblogs.microsoft.com/oldnewthing/20180314-00/?p=98235