### PR TITLE
compat/media: fix handling of metadata in Android > 8

### DIFF
--- a/compat/media/media_buffer_layer.cpp
+++ b/compat/media/media_buffer_layer.cpp
@@ -172,8 +172,7 @@ MediaMetaDataWrapper* media_buffer_get_meta_data(MediaBufferWrapper *buffer)
         return NULL;
 
 #if ANDROID_VERSION_MAJOR>=8
-    android::MetaData *md = new android::MetaData(d->buffer->meta_data());
-    return new MediaMetaDataPrivate(md);
+    return new MediaMetaDataPrivate(d->buffer);
 #else
     return new MediaMetaDataPrivate(d->buffer->meta_data());
 #endif

--- a/compat/media/media_meta_data_layer.cpp
+++ b/compat/media/media_meta_data_layer.cpp
@@ -33,9 +33,20 @@ MediaMetaDataPrivate* MediaMetaDataPrivate::toPrivate(MediaMetaDataWrapper *md)
 }
 
 MediaMetaDataPrivate::MediaMetaDataPrivate() :
+#if ANDROID_VERSION_MAJOR>=8
+    data(nullptr)
+#else
     data(new android::MetaData)
+#endif
 {
 }
+
+#if ANDROID_VERSION_MAJOR>=8
+MediaMetaDataPrivate::MediaMetaDataPrivate(android::MediaBufferBase *buffer) :
+    data(buffer)
+{
+}
+#endif
 
 MediaMetaDataPrivate::MediaMetaDataPrivate(const android::sp<android::MetaData> &md) :
     data(md)


### PR DESCRIPTION
The metadata buffer is held as a member variable by the MediaBuffer
class, which returns it as a reference. We should not make a copy of it,
or any change we make to the metadata will be affecting only our local
copy.
This commit ensures that we only keep a pointer to the metadata object
which is associated with the given buffer. We also need to increase the
reference count of the buffer for the lifetime of our class, to ensure
it does not get destroyed while we are using it.

Change-Id: I87c82decb099936d9d2ac79148c1f2a7b0e7a382