### PR TITLE
[halium-9.0] hybris: hwc2: implement Device::destroyDisplay wrapper

### DIFF
--- a/compat/hwc2/hwc2_compatibility_layer.cpp
+++ b/compat/hwc2/hwc2_compatibility_layer.cpp
@@ -132,6 +132,13 @@ hwc2_compat_display_t* hwc2_compat_device_get_display_by_id(
     return display;
 }
 
+void hwc2_compat_device_destroy_display(hwc2_compat_device_t* device,
+                                        hwc2_compat_display_t* display)
+{
+    device->self->destroyDisplay(display->self->getId());
+    free(display);
+}
+
 HWC2DisplayConfig* hwc2_compat_display_get_active_config(
                             hwc2_compat_display_t* display)
 {

--- a/hybris/hwc2/hwc2.c
+++ b/hybris/hwc2/hwc2.c
@@ -40,6 +40,9 @@ HYBRIS_IMPLEMENT_FUNCTION2(hwc2, hwc2_compat_display_t*,
                            hwc2_compat_device_t*,
                            hwc2_display_t);
 
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(hwc2, hwc2_compat_device_destroy_display,
+                                hwc2_compat_device_t*, hwc2_compat_display_t*);
+
 HYBRIS_IMPLEMENT_FUNCTION1(hwc2, HWC2DisplayConfig*,
                            hwc2_compat_display_get_active_config,
                            hwc2_compat_display_t*);

--- a/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
+++ b/hybris/include/hybris/hwc2/hwc2_compatibility_layer.h
@@ -82,6 +82,9 @@ extern "C" {
                                 hwc2_compat_device_t* device,
                                 hwc2_display_t id);
 
+    void hwc2_compat_device_destroy_display(hwc2_compat_device_t* device,
+                                            hwc2_compat_display_t* display);
+
     HWC2DisplayConfig* hwc2_compat_display_get_active_config(
                                 hwc2_compat_display_t* display);
 


### PR DESCRIPTION
Device::destroyDisplay was not exposed in the compat layer, thus clients had no way to destroy displays inside `mDisplays`, potentially leaving disconnected displays behind.