### PR TITLE
hybris: media: Make media_buffer_destroy delete the buffer

### DIFF
--- a/compat/media/media_buffer_layer.cpp
+++ b/compat/media/media_buffer_layer.cpp
@@ -35,24 +35,26 @@ MediaBufferPrivate* MediaBufferPrivate::toPrivate(MediaBufferWrapper *buffer)
 }
 
 #if ANDROID_VERSION_MAJOR>=8
-MediaBufferPrivate::MediaBufferPrivate(android::MediaBufferBase *buffer) :
+MediaBufferPrivate::MediaBufferPrivate(android::MediaBufferBase *buffer, bool managedByWrapper) :
 #else
-MediaBufferPrivate::MediaBufferPrivate(android::MediaBuffer *buffer) :
+MediaBufferPrivate::MediaBufferPrivate(android::MediaBuffer *buffer, bool managedByWrapper) :
 #endif
     buffer(buffer),
     return_callback(NULL),
-    return_callback_data(NULL)
+    return_callback_data(NULL),
+    isBufferManagedByWrapper(managedByWrapper)
 {
 }
 
 MediaBufferPrivate::MediaBufferPrivate() :
-    buffer(NULL)
+    buffer(NULL),
+    isBufferManagedByWrapper(true)
 {
 }
 
 MediaBufferPrivate::~MediaBufferPrivate()
 {
-    if (buffer)
+    if (isBufferManagedByWrapper && buffer)
         buffer->release();
 }
 

--- a/compat/media/media_buffer_priv.h
+++ b/compat/media/media_buffer_priv.h
@@ -34,9 +34,9 @@ public:
     static MediaBufferPrivate* toPrivate(MediaBufferWrapper *source);
 
 #if ANDROID_VERSION_MAJOR>=8
-    MediaBufferPrivate(android::MediaBufferBase *data);
+    MediaBufferPrivate(android::MediaBufferBase *data, bool managedByWrapper = true);
 #else
-    MediaBufferPrivate(android::MediaBuffer *data);
+    MediaBufferPrivate(android::MediaBuffer *data, bool managedByWrapper = true);
 #endif
     MediaBufferPrivate();
     ~MediaBufferPrivate();
@@ -52,6 +52,7 @@ public:
 #endif
     MediaBufferReturnCallback return_callback;
     void *return_callback_data;
+    bool isBufferManagedByWrapper;
 };
 
 struct MediaABufferPrivate

--- a/compat/media/media_codec_source_layer.cpp
+++ b/compat/media/media_codec_source_layer.cpp
@@ -356,7 +356,9 @@ bool media_codec_source_read(MediaCodecSourceWrapper *source, MediaBufferWrapper
     if (err != android::OK)
         return false;
 
-    *buffer = new MediaBufferPrivate(buff);
+    // This MediaCodecSource layer is the oddball here. It's using a MediaBuffer that's
+    // created by MediaCodecSource into our private object, hence it's already managed.
+    *buffer = new MediaBufferPrivate(buff, false);
 
     return true;
 }


### PR DESCRIPTION
Instead of lowering the reference count on the buffer (implicitly,
due to the Wrapper's dtor release() call) in the hopes of it getting
deleted, make sure that an explicit destroy is an explicit destroy.

Newer versions of Android apparently have refcounting bugs,
as noticed by LineageOS:
https://review.lineageos.org/c/LineageOS/android_frameworks_av/+/258972/2

Because of this the implicit release will not release the buffer at all.
Proposed solution: Have consumers of this API rely on checking the
refcount themselves and release/destroy accordingly.

Change-Id: I90afe51361c8453b4f7b63bfb02d327ee50a58ec