### PR TITLE
compat: media: Send CSD data separately to en/decoder

### DIFF
--- a/compat/media/media_codec_layer.cpp
+++ b/compat/media/media_codec_layer.cpp
@@ -352,17 +352,19 @@ int media_codec_configure(MediaCodecDelegate delegate, MediaFormat format, Surfa
     if (format_priv->max_input_size > 0)
         aformat->setInt32("max-input-size", format_priv->max_input_size);
 
-    if (format_priv->csd.get() != NULL) {
-        const size_t csd_size = format_priv->csd->size();
+    for (auto it = format_priv->csd.begin(); it != format_priv->csd.end(); it++) {
+        const AString key = it->first;
+        const sp<ABuffer> csd = it->second;
+        const size_t csd_size = csd->size();
 
         ALOGD("Adding csd (%zu bytes)", csd_size);
 
         sp<ABuffer> buffer = new ABuffer(csd_size);
-        memcpy(buffer->data(), format_priv->csd->data(), csd_size);
+        memcpy(buffer->data(), csd->data(), csd_size);
 
         buffer->meta()->setInt32("csd", true);
         buffer->meta()->setInt64("timeUs", 0);
-        aformat->setBuffer("csd-0", buffer);
+        aformat->setBuffer(key.c_str(), buffer);
     }
 
     ALOGD("Format: %s", aformat->debugString().c_str());
@@ -433,7 +435,6 @@ int media_codec_queue_csd(MediaCodecDelegate delegate, MediaFormat format)
 
     _MediaCodecDelegate *d = get_internal_delegate(delegate);
     _MediaFormat *format_priv = static_cast<_MediaFormat*>(format);
-    assert(format_priv->csd != NULL);
 
     status_t err = OK;
 
@@ -445,9 +446,9 @@ int media_codec_queue_csd(MediaCodecDelegate delegate, MediaFormat format)
     err = d->media_codec->getInputBuffers(&input_bufs[0]);
     CHECK_EQ(err, static_cast<status_t>(OK));
 
-    for (size_t i=0; i<2; ++i)
+    for (auto it = format_priv->csd.begin(); it != format_priv->csd.end(); it++)
     {
-        const sp<ABuffer> &srcBuffer = format_priv->csd;
+        const sp<ABuffer> &srcBuffer = it->second;
 
         size_t index = 0;
         err = d->media_codec->dequeueInputBuffer(&index, -1ll);

--- a/compat/media/media_format_layer.cpp
+++ b/compat/media/media_format_layer.cpp
@@ -108,8 +108,7 @@ void media_format_set_byte_buffer(MediaFormat format, const char *key, uint8_t *
     if (key == NULL || data == NULL || size == 0)
         return;
 
-    mf->csd_key_name = AString(key);
-    mf->csd = sp<ABuffer>(new ABuffer(data, size));
+    mf->csd[AString(key)] = sp<ABuffer>(new ABuffer(data, size));
 }
 
 const char* media_format_get_mime(MediaFormat format)

--- a/compat/media/media_format_layer_priv.h
+++ b/compat/media/media_format_layer_priv.h
@@ -22,6 +22,8 @@
 #include <stddef.h>
 #include <unistd.h>
 
+#include <map>
+
 #include <media/stagefright/foundation/AString.h>
 #include <media/stagefright/foundation/ABuffer.h>
 
@@ -34,7 +36,6 @@ struct _MediaFormat : public android::RefBase
         width(0),
         height(0),
         max_input_size(0),
-        csd(NULL),
         stride(0),
         slice_height(0),
         color_format(0),
@@ -51,8 +52,7 @@ struct _MediaFormat : public android::RefBase
     int32_t width;
     int32_t height;
     int32_t max_input_size;
-    android::AString csd_key_name;
-    android::sp<android::ABuffer> csd;
+    std::map<android::AString, android::sp<android::ABuffer>> csd;
 
     int32_t stride;
     int32_t slice_height;


### PR DESCRIPTION
H264 decoders consume two chunks of Codec-specific data (CSD): csd-0 & csd-1

To make the compat layer follow the API design remove the hardcoded "csd-0" passing and use the right <csd-n> key when passing to the MediaFormat.

Enables CSD-1 to be passed to the OMX decoder.