### PR TITLE
[Halium 10] compat/media/stch: use RefBase's refcount instead of its own

### DIFF
--- a/compat/media/surface_texture_client_hybris_priv.h
+++ b/compat/media/surface_texture_client_hybris_priv.h
@@ -66,7 +66,6 @@ public:
     void setHardwareRendering(bool do_hardware_rendering);
     bool hardwareRendering();
 
-    unsigned int refcount;
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=2
     android::sp<android::SurfaceTexture> surface_texture;
 #else


### PR DESCRIPTION
`Surface` is a `RefBase`, and seems to always have been. That means we inherited its reference counting ability, and don't have to maintain our own. In fact, trying to maintain our own clashes with various places (e.g. `MediaCodec::configure()`) where it expects a `RefBase`-based smart pointer.

So, instead of trying to fight it, just use it. This will cooperate with all the consumers of this class just fine.

Bug-UBports: https://gitlab.com/ubports/development/core/packaging/qtwebengine/-/issues/11
Change-Id: I581aaef1999bb1d51c3c0a823d524a0373fd5c51